### PR TITLE
Stops compiler from complaining arch type

### DIFF
--- a/BoardConfig.mk
+++ b/BoardConfig.mk
@@ -18,6 +18,10 @@
 # Use the part that is common between all allwinner
 include device/allwinner/common/BoardConfig.mk
 
+# Stops compiler from complaining about arch type
+TARGET_CPU_VARIANT := cortex-a8
+TARGET_ARCH := arm
+
 BOARD_CUSTOM_RECOVERY_KEYMAPPING := ../../device/allwinner/cubieboard/recovery_keys.c
 
 TARGET_KERNEL_CONFIG := cubieboard_defconfig


### PR DESCRIPTION
Fixing the error below

``` bash
build/core/config.mk:162: *** TARGET_ARCH not defined by board config: device/allwinner/cubieboard/BoardConfig.mk.  Stop.
```
